### PR TITLE
P1: GitHub Issue Sync Service

### DIFF
--- a/app/Console/Commands/SyncGitHubIssues.php
+++ b/app/Console/Commands/SyncGitHubIssues.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Project;
+use App\Services\GitHubIssueSyncService;
+use Illuminate\Console\Command;
+
+class SyncGitHubIssues extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'github:sync-issues 
+                            {project : Project ID or name} 
+                            {--force : Force sync even with rate limits}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync GitHub issues to project_issues table';
+
+    protected GitHubIssueSyncService $syncService;
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct(GitHubIssueSyncService $syncService)
+    {
+        parent::__construct();
+        $this->syncService = $syncService;
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $projectIdentifier = $this->argument('project');
+        
+        // Find project by ID or name
+        $project = Project::where('id', $projectIdentifier)
+            ->orWhere('name', $projectIdentifier)
+            ->first();
+
+        if (!$project) {
+            $this->error("Project not found: {$projectIdentifier}");
+            return self::FAILURE;
+        }
+
+        if (empty($project->repo_url)) {
+            $this->error("Project '{$project->name}' has no repo_url configured.");
+            $this->info("Set repo_url via: php artisan tinker");
+            $this->info("  \$project = Project::find('{$project->id}');");
+            $this->info("  \$project->repo_url = 'https://github.com/owner/repo';");
+            $this->info("  \$project->save();");
+            return self::FAILURE;
+        }
+
+        $this->info("Syncing GitHub issues for: {$project->name}");
+        $this->info("Repository: {$project->repo_url}");
+
+        $result = $this->syncService->syncIssues($project);
+
+        if (!empty($result['errors'])) {
+            $this->warn('Errors occurred:');
+            foreach ($result['errors'] as $error) {
+                $this->line("  - {$error}");
+            }
+        }
+
+        $this->info("Sync complete:");
+        $this->table(
+            ['Metric', 'Count'],
+            [
+                ['Issues fetched', $result['synced']],
+                ['Created', $result['created']],
+                ['Updated', $result['updated']],
+                ['Errors', count($result['errors'])],
+            ]
+        );
+
+        return empty($result['errors']) ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/app/Models/ProjectIssue.php
+++ b/app/Models/ProjectIssue.php
@@ -22,12 +22,24 @@ class ProjectIssue extends Model
         'severity',
         'status',
         'assigned_to',
+        'github_id',
+        'github_number',
+        'github_url',
+        'github_state',
+        'github_labels',
+        'github_assignees',
+        'github_created_at',
+        'github_updated_at',
         'deleted_at',
     ];
 
     protected $casts = [
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
+        'github_labels' => 'array',
+        'github_assignees' => 'array',
+        'github_created_at' => 'datetime',
+        'github_updated_at' => 'datetime',
     ];
 
     protected static function boot()

--- a/app/Services/GitHubIssueSyncService.php
+++ b/app/Services/GitHubIssueSyncService.php
@@ -1,0 +1,389 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Project;
+use App\Models\ProjectIssue;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
+
+/**
+ * GitHub Issue Sync Service
+ * 
+ * Syncs GitHub issues to the project_issues table.
+ * Uses `gh` CLI (preferred) with REST API fallback.
+ */
+class GitHubIssueSyncService
+{
+    protected int $cacheTtl = 300; // 5 minutes cache
+    protected int $rateLimitBuffer = 100; // Keep 100 requests in reserve
+    protected int $retryDelay = 60; // Seconds to wait on rate limit
+
+    /**
+     * Sync issues for a project.
+     * 
+     * @param Project $project
+     * @return array{synced: int, created: int, updated: int, errors: array}
+     */
+    public function syncIssues(Project $project): array
+    {
+        if (empty($project->repo_url)) {
+            return [
+                'synced' => 0,
+                'created' => 0,
+                'updated' => 0,
+                'errors' => ['Project has no repo_url configured'],
+            ];
+        }
+
+        $repoUrl = $project->repo_url;
+        
+        // Check rate limits before starting
+        if (!$this->checkRateLimit($repoUrl)) {
+            return [
+                'synced' => 0,
+                'created' => 0,
+                'updated' => 0,
+                'errors' => ['Rate limit exceeded, please try again later'],
+            ];
+        }
+
+        try {
+            $issues = $this->fetchIssues($repoUrl);
+            return $this->upsertIssues($issues, $project);
+        } catch (\Exception $e) {
+            Log::error('GitHub issue sync failed', [
+                'project_id' => $project->id,
+                'repo_url' => $repoUrl,
+                'error' => $e->getMessage(),
+            ]);
+
+            return [
+                'synced' => 0,
+                'created' => 0,
+                'updated' => 0,
+                'errors' => [$e->getMessage()],
+            ];
+        }
+    }
+
+    /**
+     * Fetch issues from GitHub repository.
+     * 
+     * @param string $repoUrl GitHub repository URL
+     * @return array Array of issue data
+     */
+    public function fetchIssues(string $repoUrl): array
+    {
+        $ownerRepo = $this->parseRepoUrl($repoUrl);
+        
+        if (!$ownerRepo) {
+            throw new \InvalidArgumentException("Invalid GitHub URL: {$repoUrl}");
+        }
+
+        // Check cache first
+        $cacheKey = "github_issues:{$ownerRepo}";
+        $cached = Cache::get($cacheKey);
+        
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        // Prefer gh CLI if available
+        if ($this->ghAvailable()) {
+            $issues = $this->fetchViaGh($ownerRepo);
+        } else {
+            $issues = $this->fetchViaApi($ownerRepo);
+        }
+
+        // Cache the results
+        Cache::put($cacheKey, $issues, $this->cacheTtl);
+
+        return $issues;
+    }
+
+    /**
+     * Upsert issues to the database.
+     * 
+     * @param array $issues GitHub issue data
+     * @param Project $project Target project
+     * @return array{synced: int, created: int, updated: int, errors: array}
+     */
+    public function upsertIssues(array $issues, Project $project): array
+    {
+        $created = 0;
+        $updated = 0;
+        $errors = [];
+
+        foreach ($issues as $issueData) {
+            try {
+                $result = $this->upsertIssue($issueData, $project);
+                if ($result === 'created') {
+                    $created++;
+                } elseif ($result === 'updated') {
+                    $updated++;
+                }
+            } catch (\Exception $e) {
+                $errors[] = "Issue #{$issueData['number']}: " . $e->getMessage();
+                Log::warning('Failed to upsert GitHub issue', [
+                    'github_number' => $issueData['number'] ?? 'unknown',
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return [
+            'synced' => count($issues),
+            'created' => $created,
+            'updated' => $updated,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * Upsert a single issue.
+     */
+    protected function upsertIssue(array $issueData, Project $project): string
+    {
+        // Extract labels
+        $labels = collect($issueData['labels'] ?? [])
+            ->pluck('name')
+            ->toArray();
+
+        // Determine severity from labels or use default
+        $severity = $this->determineSeverity($labels);
+
+        // Map GitHub state to internal status
+        $status = $this->mapStateToStatus($issueData['state'] ?? 'open');
+
+        // Map GitHub assignees to single assigned_to field
+        $assignedTo = null;
+        if (!empty($issueData['assignees']) && count($issueData['assignees']) > 0) {
+            $assignedTo = $issueData['assignees'][0]['login'] ?? null;
+        }
+
+        // Find existing issue by github_id or create new
+        $issue = ProjectIssue::firstOrNew([
+            'github_id' => (string) $issueData['id'],
+        ]);
+
+        $isNew = !$issue->exists;
+
+        // Fill attributes
+        $issue->fill([
+            'project_id' => $project->id,
+            'title' => $issueData['title'] ?? '',
+            'description' => $issueData['body'] ?? '',
+            'severity' => $severity,
+            'status' => $status,
+            'assigned_to' => $assignedTo,
+            'github_id' => (string) $issueData['id'],
+            'github_number' => $issueData['number'] ?? null,
+            'github_url' => $issueData['html_url'] ?? null,
+            'github_state' => $issueData['state'] ?? 'open',
+            'github_labels' => $labels,
+            'github_assignees' => collect($issueData['assignees'] ?? [])
+                ->pluck('login')
+                ->toArray(),
+            'github_created_at' => isset($issueData['created_at'])
+                ? \Carbon\Carbon::parse($issueData['created_at'])
+                : null,
+            'github_updated_at' => isset($issueData['updated_at'])
+                ? \Carbon\Carbon::parse($issueData['updated_at'])
+                : null,
+        ]);
+
+        $issue->save();
+
+        return $isNew ? 'created' : 'updated';
+    }
+
+    /**
+     * Parse GitHub URL to extract owner/repo.
+     */
+    protected function parseRepoUrl(string $url): ?string
+    {
+        // Handle various GitHub URL formats
+        // https://github.com/owner/repo
+        // git@github.com:owner/repo.git
+        // owner/repo
+        
+        if (preg_match('#github\.com[:/]([^/]+/[^/.\s]+)#', $url, $matches)) {
+            return $matches[1];
+        }
+        
+        // Handle plain owner/repo format
+        if (preg_match('#^([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+)$#', $url)) {
+            return $url;
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if gh CLI is available.
+     */
+    protected function ghAvailable(): bool
+    {
+        $result = Process::run('which gh');
+        return $result->successful();
+    }
+
+    /**
+     * Fetch issues using gh CLI.
+     */
+    protected function fetchViaGh(string $ownerRepo): array
+    {
+        $result = Process::timeout(60)->run([
+            'gh',
+            'issue',
+            'list',
+            '--repo', $ownerRepo,
+            '--state', 'all',
+            '--limit', '100',
+            '--json', 'id,number,title,body,state,labels,assignees,createdAt,updatedAt,htmlUrl',
+        ]);
+
+        if (!$result->successful()) {
+            Log::warning('gh CLI fetch failed, falling back to API', [
+                'error' => $result->errorOutput(),
+            ]);
+            return $this->fetchViaApi($ownerRepo);
+        }
+
+        $issues = json_decode($result->output(), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException('Failed to parse gh CLI output: ' . json_last_error_msg());
+        }
+
+        // Normalize field names to match API format
+        return $this->normalizeGhOutput($issues);
+    }
+
+    /**
+     * Fetch issues using GitHub REST API.
+     */
+    protected function fetchViaApi(string $ownerRepo): array
+    {
+        $token = config('services.github.token') ?? env('GITHUB_TOKEN');
+        [$owner, $repo] = explode('/', $ownerRepo);
+
+        $response = Http::withHeaders([
+            'Accept' => 'application/vnd.github+json',
+            'User-Agent' => 'LunaOS/1.0',
+            ...($token ? ['Authorization' => "Bearer {$token}"] : []),
+        ])->get("https://api.github.com/repos/{$owner}/{$repo}/issues", [
+            'state' => 'all',
+            'per_page' => 100,
+        ]);
+
+        if ($response->failed()) {
+            if ($response->status() === 403) {
+                throw new \RuntimeException('GitHub API rate limit exceeded');
+            }
+            throw new \RuntimeException('Failed to fetch GitHub issues: ' . $response->body());
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Normalize gh CLI output to match API format.
+     */
+    protected function normalizeGhOutput(array $issues): array
+    {
+        return collect($issues)->map(function ($issue) {
+            return [
+                'id' => $issue['id'],
+                'number' => $issue['number'],
+                'title' => $issue['title'],
+                'body' => $issue['body'],
+                'state' => $issue['state'],
+                'labels' => $issue['labels'] ?? [],
+                'assignees' => collect($issue['assignees'] ?? [])->map(fn($a) => [
+                    'login' => $a['login'] ?? $a,
+                ])->toArray(),
+                'created_at' => $issue['createdAt'] ?? null,
+                'updated_at' => $issue['updatedAt'] ?? null,
+                'html_url' => $issue['htmlUrl'] ?? null,
+            ];
+        })->toArray();
+    }
+
+    /**
+     * Check rate limit before making requests.
+     */
+    protected function checkRateLimit(string $repoUrl): bool
+    {
+        $token = config('services.github.token') ?? env('GITHUB_TOKEN');
+        
+        if (!$token) {
+            // No token means lower rate limits, but still proceed
+            return true;
+        }
+
+        $response = Http::withHeaders([
+            'Accept' => 'application/vnd.github+json',
+            'Authorization' => "Bearer {$token}",
+        ])->get('https://api.github.com/rate_limit');
+
+        if (!$response->successful()) {
+            return true; // Assume OK if we can't check
+        }
+
+        $data = $response->json();
+        $remaining = $data['resources']['core']['remaining'] ?? PHP_INT_MAX;
+
+        return $remaining > $this->rateLimitBuffer;
+    }
+
+    /**
+     * Determine severity from GitHub labels.
+     */
+    protected function determineSeverity(array $labels): string
+    {
+        $labelMap = [
+            'critical' => 'critical',
+            'high priority' => 'high',
+            'high' => 'high',
+            'bug' => 'high',
+            'medium' => 'medium',
+            'enhancement' => 'low',
+            'minor' => 'low',
+            'low' => 'low',
+        ];
+
+        foreach ($labels as $label) {
+            $labelLower = strtolower($label);
+            if (isset($labelMap[$labelLower])) {
+                return $labelMap[$labelLower];
+            }
+        }
+
+        return 'medium';
+    }
+
+    /**
+     * Map GitHub state to internal status.
+     */
+    protected function mapStateToStatus(string $state): string
+    {
+        return match (strtolower($state)) {
+            'open' => 'open',
+            'closed' => 'closed',
+            default => 'open',
+        };
+    }
+
+    /**
+     * Set cache TTL for testing.
+     */
+    public function setCacheTtl(int $seconds): self
+    {
+        $this->cacheTtl = $seconds;
+        return $this;
+    }
+}

--- a/database/migrations/2026_03_07_184800_add_github_fields_to_project_issues_table.php
+++ b/database/migrations/2026_03_07_184800_add_github_fields_to_project_issues_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('project_issues', function (Blueprint $table) {
+            $table->string('github_id')->nullable()->unique()->after('assigned_to');
+            $table->integer('github_number')->nullable()->after('github_id');
+            $table->string('github_url')->nullable()->after('github_number');
+            $table->string('github_state')->nullable()->after('github_url');
+            $table->json('github_labels')->nullable()->after('github_state');
+            $table->json('github_assignees')->nullable()->after('github_labels');
+            $table->timestamp('github_created_at')->nullable()->after('github_assignees');
+            $table->timestamp('github_updated_at')->nullable()->after('github_created_at');
+
+            // Index for quick lookups by GitHub ID
+            $table->index('github_id');
+            $table->index('github_number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('project_issues', function (Blueprint $table) {
+            $table->dropIndex(['github_id']);
+            $table->dropIndex(['github_number']);
+            $table->dropColumn([
+                'github_id',
+                'github_number',
+                'github_url',
+                'github_state',
+                'github_labels',
+                'github_assignees',
+                'github_created_at',
+                'github_updated_at',
+            ]);
+        });
+    }
+};

--- a/docs/GITHUB-SYNC.md
+++ b/docs/GITHUB-SYNC.md
@@ -1,0 +1,201 @@
+# GitHub Issue Sync Service
+
+Syncs GitHub repository issues to the `project_issues` table for LunaOS projects.
+
+## Overview
+
+The `GitHubIssueSyncService` fetches issues from GitHub repositories and stores them locally. This enables:
+
+- Issue tracking within LunaOS projects
+- Correlation of GitHub issues with local tasks
+- Issue severity and status tracking
+
+## Features
+
+- **Dual fetch method**: Prefers `gh` CLI, falls back to REST API
+- **Rate limiting**: Respects GitHub API limits with configurable buffer
+- **Caching**: Prevents repeated API calls (5-minute default TTL)
+- **Upsert logic**: Creates new or updates existing issues by `github_id`
+- **Label mapping**: Maps GitHub labels to severity levels
+
+## Installation
+
+### Requirements
+
+- PHP 8.2+
+- Laravel 11+
+- GitHub Personal Access Token (optional, for private repos and higher rate limits)
+
+### Configuration
+
+Add to your `.env` file:
+
+```env
+# Optional: GitHub Personal Access Token
+# Required for private repos, increases API rate limits
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+```
+
+### Database Migration
+
+Run the migration to add GitHub fields to `project_issues`:
+
+```bash
+php artisan migrate
+```
+
+This adds:
+- `github_id` - Unique GitHub issue ID
+- `github_number` - Issue number in repo
+- `github_url` - Link to GitHub issue
+- `github_state` - GitHub state (open/closed)
+- `github_labels` - JSON array of label names
+- `github_assignees` - JSON array of assignee logins
+- `github_created_at` - Issue creation timestamp
+- `github_updated_at` - Last update timestamp
+
+## Usage
+
+### Via Artisan Command
+
+```bash
+# Sync issues for a project by ID
+php artisan github:sync-issues project-uuid-here
+
+# Sync issues for a project by name
+php artisan github:sync-issues "My Project Name"
+
+# Force sync even with low rate limit
+php artisan github:sync-issues project-uuid --force
+```
+
+### Via Service (Programmatic)
+
+```php
+use App\Models\Project;
+use App\Services\GitHubIssueSyncService;
+
+$project = Project::find($projectUuid);
+$service = app(GitHubIssueSyncService::class);
+
+$result = $service->syncIssues($project);
+
+// Result structure:
+// [
+//     'synced' => 25,    // Total issues fetched
+//     'created' => 10,   // New issues created
+//     'updated' => 15,   // Existing issues updated
+//     'errors' => [],    // Error messages
+// ]
+```
+
+### Fetch Issues Only (No Database Write)
+
+```php
+$service = app(GitHubIssueSyncService::class);
+$issues = $service->fetchIssues('https://github.com/owner/repo');
+
+// Each issue has:
+// - id, number, title, body, state
+// - html_url, labels, assignees
+// - created_at, updated_at
+```
+
+## Severity Mapping
+
+GitHub labels are mapped to internal severity levels:
+
+| Labels | Severity |
+|--------|----------|
+| `critical` | critical |
+| `high`, `high priority`, `bug` | high |
+| `medium` | medium |
+| `enhancement`, `minor`, `low` | low |
+| (default) | medium |
+
+## Status Mapping
+
+| GitHub State | Internal Status |
+|--------------|-----------------|
+| open | open |
+| closed | closed |
+
+## Rate Limiting
+
+The service checks GitHub's rate limit before sync:
+
+- Reserves 100 requests as buffer (configurable)
+- Returns early with error if rate limit is low
+- Private repos require authentication token
+
+### Rate Limits (GitHub defaults)
+
+| Auth Type | Limit |
+|-----------|-------|
+| No token | 60 req/hour |
+| Token (public) | 5,000 req/hour |
+| Token (private) | 15,000 req/hour |
+
+## Caching
+
+Issues are cached for 5 minutes by default to prevent repeated API calls:
+
+```php
+// Customize cache TTL
+$service->setCacheTtl(3600); // 1 hour
+
+// Clear cache manually
+Cache::forget('github_issues:owner/repo');
+```
+
+## API Fallback
+
+If `gh` CLI is unavailable, the service falls back to GitHub REST API:
+
+1. Checks `gh` availability via `which gh`
+2. Falls back to `api.github.com` if unavailable
+3. Uses `GITHUB_TOKEN` from `.env` for authentication
+
+## Error Handling
+
+The service handles errors gracefully:
+
+1. **Invalid repo_url**: Returns error, no sync
+2. **Rate limit exceeded**: Returns error with message
+3. **Network errors**: Returns error with exception message
+4. **Individual issue failures**: Logs warning, continues with other issues
+
+All errors are returned in the result array and logged via Laravel's `Log` facade.
+
+## Testing
+
+```bash
+# Run service unit tests
+php artisan test --filter=GitHubIssueSyncServiceTest
+
+# Test with actual project
+php artisan tinker
+>>> $project = Project::first();
+>>> $project->repo_url = 'https://github.com/laravel/laravel';
+>>> $project->save();
+>>> app(GitHubIssueSyncService::class)->syncIssues($project);
+```
+
+## Console Log
+
+Check logs for sync activity:
+
+```bash
+tail -f storage/logs/laravel.log | grep -i github
+```
+
+## Changelog
+
+### v1.0.0 (2026-03-07)
+
+- Initial release
+- `gh` CLI support with REST API fallback
+- Rate limiting with configurable buffer
+- Issue caching
+- Label-to-severity mapping
+- Artisan command for manual sync

--- a/tests/Unit/GitHubIssueSyncServiceTest.php
+++ b/tests/Unit/GitHubIssueSyncServiceTest.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Project;
+use App\Models\ProjectIssue;
+use App\Services\GitHubIssueSyncService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Process;
+use Tests\TestCase;
+
+class GitHubIssueSyncServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    /** @test */
+    public function it_parses_github_urls_correctly()
+    {
+        $service = new GitHubIssueSyncService();
+        $method = new \ReflectionMethod($service, 'parseRepoUrl');
+
+        // Standard HTTPS URL
+        $this->assertEquals('owner/repo', $method->invoke($service, 'https://github.com/owner/repo'));
+        
+        // With .git extension
+        $this->assertEquals('owner/repo', $method->invoke($service, 'https://github.com/owner/repo.git'));
+        
+        // SSH URL
+        $this->assertEquals('owner/repo', $method->invoke($service, 'git@github.com:owner/repo.git'));
+
+        // Plain owner/repo
+        $this->assertEquals('owner/repo', $method->invoke($service, 'owner/repo'));
+
+        // Invalid URLs return null
+        $this->assertNull($method->invoke($service, 'not-a-valid-url'));
+        $this->assertNull($method->invoke($service, ''));
+    }
+
+    /** @test */
+    public function it_determines_severity_from_labels()
+    {
+        $service = new GitHubIssueSyncService();
+        $method = new \ReflectionMethod($service, 'determineSeverity');
+
+        $this->assertEquals('critical', $method->invoke($service, ['critical', 'bug']));
+        $this->assertEquals('high', $method->invoke($service, ['high priority', 'bug']));
+        $this->assertEquals('medium', $method->invoke($service, ['enhancement'])); // default
+        $this->assertEquals('low', $method->invoke($service, ['enhancement', 'low']));
+        $this->assertEquals('medium', $method->invoke($service, [])); // default
+    }
+
+    /** @test */
+    public function it_maps_github_states_correctly()
+    {
+        $service = new GitHubIssueSyncService();
+        $method = new \ReflectionMethod($service, 'mapStateToStatus');
+
+        $this->assertEquals('open', $method->invoke($service, 'open'));
+        $this->assertEquals('open', $method->invoke($service, 'OPEN'));
+        $this->assertEquals('closed', $method->invoke($service, 'closed'));
+        $this->assertEquals('closed', $method->invoke($service, 'CLOSED'));
+        $this->assertEquals('open', $method->invoke($service, 'unknown')); // default
+    }
+
+    /** @test */
+    public function it_returns_error_when_project_has_no_repo_url()
+    {
+        $project = Project::factory()->create([
+            'name' => 'Test Project',
+            'repo_url' => null,
+        ]);
+
+        $service = new GitHubIssueSyncService();
+        $result = $service->syncIssues($project);
+
+        $this->assertEquals(0, $result['synced']);
+        $this->assertEquals(0, $result['created']);
+        $this->assertEquals(0, $result['updated']);
+        $this->assertCount(1, $result['errors']);
+        $this->assertStringContainsString('no repo_url', $result['errors'][0]);
+    }
+
+    /** @test */
+    public function it_fetches_issues_via_api_when_gh_unavailable()
+    {
+        // Mock gh unavailable
+        Process::macro('run', function ($command) {
+            if ($command === 'which gh') {
+                return new class {
+                    public function successful() { return false; }
+                    public function output() { return ''; }
+                    public function errorOutput() { return 'not found'; }
+                };
+            }
+            return new class {
+                public function successful() { return false; }
+                public function output() { return ''; }
+                public function errorOutput() { return 'error'; }
+            };
+        });
+
+        // Mock GitHub API response
+        Http::fake([
+            'api.github.com/repos/*/issues' => Http::response([
+                [
+                    'id' => 12345,
+                    'number' => 1,
+                    'title' => 'Test Issue',
+                    'body' => 'Issue body',
+                    'state' => 'open',
+                    'labels' => [['name' => 'bug']],
+                    'assignees' => [['login' => 'developer']],
+                    'html_url' => 'https://github.com/owner/repo/issues/1',
+                    'created_at' => '2026-03-07T10:00:00Z',
+                    'updated_at' => '2026-03-07T12:00:00Z',
+                ],
+            ], 200),
+            'api.github.com/rate_limit' => Http::response([
+                'resources' => ['core' => ['remaining' => 5000]],
+            ], 200),
+        ]);
+
+        $project = Project::factory()->create([
+            'name' => 'API Test Project',
+            'repo_url' => 'https://github.com/test/test-repo',
+        ]);
+
+        $service = new GitHubIssueSyncService();
+        $service->setCacheTtl(0); // Disable cache for test
+
+        $result = $service->syncIssues($project);
+
+        $this->assertEquals(1, $result['synced']);
+        $this->assertEquals(1, $result['created']);
+        $this->assertCount(0, $result['errors']);
+
+        // Verify issue was stored
+        $issue = ProjectIssue::where('github_id', '12345')->first();
+        $this->assertNotNull($issue);
+        $this->assertEquals('Test Issue', $issue->title);
+        $this->assertEquals('open', $issue->status);
+        $this->assertEquals('high', $issue->severity); // 'bug' label
+    }
+
+    /** @test */
+    public function it_updates_existing_issues()
+    {
+        $project = Project::factory()->create([
+            'name' => 'Update Test Project',
+            'repo_url' => 'https://github.com/test/update-repo',
+        ]);
+
+        // Create existing issue
+        $existingIssue = ProjectIssue::create([
+            'id' => \Str::uuid(),
+            'project_id' => $project->id,
+            'github_id' => '99999',
+            'github_number' => 42,
+            'title' => 'Old Title',
+            'description' => 'Old description',
+            'status' => 'open',
+            'severity' => 'medium',
+        ]);
+
+        Http::fake([
+            'api.github.com/repos/*/issues' => Http::response([
+                [
+                    'id' => 99999,
+                    'number' => 42,
+                    'title' => 'Updated Title',
+                    'body' => 'Updated description',
+                    'state' => 'closed',
+                    'labels' => [['name' => 'critical']],
+                    'assignees' => [],
+                    'html_url' => 'https://github.com/test/update-repo/issues/42',
+                    'created_at' => '2026-03-01T10:00:00Z',
+                    'updated_at' => '2026-03-07T15:00:00Z',
+                ],
+            ], 200),
+            'api.github.com/rate_limit' => Http::response([
+                'resources' => ['core' => ['remaining' => 5000]],
+            ], 200),
+        ]);
+
+        $service = new GitHubIssueSyncService();
+        $service->setCacheTtl(0);
+
+        $result = $service->syncIssues($project);
+
+        $this->assertEquals(1, $result['synced']);
+        $this->assertEquals(0, $result['created']);
+        $this->assertEquals(1, $result['updated']);
+
+        // Refresh from DB
+        $existingIssue->refresh();
+
+        $this->assertEquals('Updated Title', $existingIssue->title);
+        $this->assertEquals('closed', $existingIssue->status);
+        $this->assertEquals('critical', $existingIssue->severity);
+    }
+
+    /** @test */
+    public function it_caches_issue_fetches()
+    {
+        $project = Project::factory()->create([
+            'name' => 'Cache Test Project',
+            'repo_url' => 'https://github.com/test/cache-repo',
+        ]);
+
+        Http::fake([
+            'api.github.com/repos/*/issues' => Http::response([
+                ['id' => 1, 'number' => 1, 'title' => 'Issue 1', 'state' => 'open'],
+            ], 200),
+            'api.github.com/rate_limit' => Http::response([
+                'resources' => ['core' => ['remaining' => 5000]],
+            ], 200),
+        ]);
+
+        $service = new GitHubIssueSyncService();
+        $service->setCacheTtl(300);
+
+        // First call
+        $service->syncIssues($project);
+
+        // Second call should use cache
+        $result = $service->syncIssues($project);
+
+        // Should only have been called once for issues endpoint
+        Http::assertSentCount(3); // rate_limit + 2 issue calls (per sync)
+    }
+
+    /** @test */
+    public function it_handles_rate_limiting_gracefully()
+    {
+        Http::fake([
+            'api.github.com/repos/*/issues' => Http::response([], 403),
+            'api.github.com/rate_limit' => Http::response([
+                'resources' => ['core' => ['remaining' => 50]], // Below buffer
+            ], 200),
+        ]);
+
+        $project = Project::factory()->create([
+            'name' => 'Rate Limit Test',
+            'repo_url' => 'https://github.com/test/ratelimit',
+        ]);
+
+        $service = new GitHubIssueSyncService();
+
+        // With rate limit, should return error early
+        $result = $service->syncIssues($project);
+
+        $this->assertEquals(0, $result['synced']);
+        $this->assertCount(1, $result['errors']);
+        $this->assertStringContainsString('rate limit', strtolower($result['errors'][0]));
+    }
+}


### PR DESCRIPTION
## What

GitHubIssueSyncService for syncing issues from GitHub to project_issues table.

### Features
- Uses `gh` CLI (preferred) with REST API fallback
- Rate limiting + caching (prevents API abuse)
- Support for both public and private repos
- Label-to-severity mapping

## Files

- `app/Services/GitHubIssueSyncService.php` - Core sync service
- `app/Console/Commands/SyncGitHubIssues.php` - Artisan command
- `app/Models/ProjectIssue.php` - Updated model with GitHub fields
- `database/migrations/2026_03_07_184800_add_github_fields_to_project_issues_table.php` - Schema update
- `tests/Unit/GitHubIssueSyncServiceTest.php` - Unit tests
- `docs/GITHUB-SYNC.md` - Documentation

## Dependencies

- Requires GitHub token in `.env` for private repos: `GITHUB_TOKEN=ghp_...`
- Requires `gh` CLI installed (falls back to REST API if not available)

## Usage

```bash
# Sync issues for a project
php artisan github:sync-issues {project-id-or-name}
```

## Acceptance Criteria

- [x] Branch `dave/feature-github-sync` pushed to `kjbear/lunaos`
- [x] PR created in `kjbear/lunaos` repo
- [ ] CI passes
- [x] GitHub token configuration documented