### PR TITLE
fix: tasks/list route returning 404 (route ordering)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -49,14 +49,14 @@ Route::view('/mission-control', 'pages.mission-control-original')->name('mission
 Route::view('/mission-control-polished', 'pages.mission-control-polished')->name('mission-control.polished');
 
 // Task routes
+// Note: Static routes MUST come before parameterized routes (/{task})
 Route::view('/tasks', 'pages.tasks')->name('tasks');
 Route::get('/tasks/board', TaskBoardUnified::class)->name('tasks.board');
 Route::get('/tasks/executive', TaskExecutive::class)->name('tasks.executive');
+Route::get('/tasks/list', TaskList::class)->name('tasks.list');
 Route::get('/tasks/create', TaskEdit::class)->name('tasks.create');
 Route::get('/tasks/{task}/edit', TaskEdit::class)->name('tasks.edit');
 Route::get('/tasks/{task}', [\App\Livewire\TaskDetail::class, 'show'])->name('tasks.show');
-// Legacy routes for backwards compatibility (use view routes above instead)
-Route::get('/tasks/list', TaskList::class)->name('tasks.list');
 
 Route::get('/org-chart', function () {
     return view('org-chart');


### PR DESCRIPTION
## Summary

Fixes #11

The `/tasks/list` route was returning 404 because it was defined AFTER the parameterized `/tasks/{task}` route in `routes/web.php`. Laravel matches routes in order, so `list` was being matched as a task ID parameter.

## Changes
- Reordered route definitions: moved `/tasks/list` before `/tasks/{task}`
- Added comment explaining why static routes must come before parameterized ones

## Testing
- All 15 navigation tests pass including `tasks list route accessible`
- `php artisan route:list --path=tasks` confirms correct ordering

## Acceptance Criteria
- [x] Route `/tasks/list` defined and working
- [x] Branch name: `dave/fix-task-list-404`
- [x] PR created