### PR TITLE
fix: Empty tabs on team detail page (Issue #31)

### DIFF
--- a/app/Livewire/Team/MemberAiConfig.php
+++ b/app/Livewire/Team/MemberAiConfig.php
@@ -19,6 +19,7 @@ class MemberAiConfig extends Component
     
     // Persona & Prompt
     public string $personaName = '';
+    public string $personaDescription = '';
     public string $systemPrompt = '';
     public string $responseStyle = 'balanced';
     public string $specialInstructions = '';
@@ -88,6 +89,7 @@ class MemberAiConfig extends Component
         'frequencyPenalty' => 'required|numeric|min:-2|max:2',
         'presencePenalty' => 'required|numeric|min:-2|max:2',
         'personaName' => 'nullable|string|max:255',
+        'personaDescription' => 'nullable|string',
         'systemPrompt' => 'nullable|string',
         'responseStyle' => 'required|string',
         'specialInstructions' => 'nullable|string',
@@ -125,7 +127,8 @@ class MemberAiConfig extends Component
         $this->presencePenalty = $config['presence_penalty'] ?? 0.0;
         
         // Persona & Prompt
-        $this->personaName = $config['persona_name'] ?? $this->member->title ?? '';
+        $this->personaName = $config['persona_name'] ?? $this->member?->title ?? '';
+        $this->personaDescription = $config['persona_description'] ?? '';
         $this->systemPrompt = $config['system_prompt'] ?? '';
         $this->responseStyle = $config['response_style'] ?? 'balanced';
         $this->specialInstructions = $config['special_instructions'] ?? '';
@@ -164,6 +167,7 @@ class MemberAiConfig extends Component
             'frequency_penalty' => (float) $this->frequencyPenalty,
             'presence_penalty' => (float) $this->presencePenalty,
             'persona_name' => $this->personaName,
+            'persona_description' => $this->personaDescription,
             'system_prompt' => $this->systemPrompt,
             'response_style' => $this->responseStyle,
             'special_instructions' => $this->specialInstructions,
@@ -196,6 +200,7 @@ class MemberAiConfig extends Component
         $this->frequencyPenalty = 0.0;
         $this->presencePenalty = 0.0;
         $this->personaName = $this->member?->title ?? '';
+        $this->personaDescription = '';
         $this->systemPrompt = '';
         $this->responseStyle = 'balanced';
         $this->specialInstructions = '';
@@ -210,6 +215,17 @@ class MemberAiConfig extends Component
         $this->customMetadata = '{}';
         
         $this->dispatch('toast-info', message: 'Form reset to defaults');
+    }
+    
+    public function toggleCapability(string $capability): void
+    {
+        $index = array_search($capability, $this->capabilities);
+        if ($index !== false) {
+            unset($this->capabilities[$index]);
+            $this->capabilities = array_values($this->capabilities);
+        } else {
+            $this->capabilities[] = $capability;
+        }
     }
     
     public function render()

--- a/docs/ISSUE-31-EMPTY-TABS-ON-DETAIL.md
+++ b/docs/ISSUE-31-EMPTY-TABS-ON-DETAIL.md
@@ -1,0 +1,69 @@
+# Issue #31: No Content in Overview or AI Config Tabs
+
+**Priority:** P1 (BLOCKER)  
+**Assignee:** Maya (Frontend)  
+**Component:** Team Module - Detail Page  
+**Related:** Issue #30, PR #32
+
+---
+
+## Problem
+
+Team member detail pages (`/team/{uuid}`) show **empty content** in both tabs after AI Config merge.
+
+---
+
+## Expected Behavior
+
+**Overview Tab:** Member info, bio, skills, status, tasks  
+**AI Config Tab:** Model settings, prompts, capabilities, operations
+
+---
+
+## Current Behavior
+
+Both tabs render but show **blank/empty content**.
+
+---
+
+## Possible Causes
+
+1. Tab switching logic broken (Alpine.js)
+2. Content conditionals wrong (`x-show`)
+3. Livewire component not rendering
+4. `$member` variable not passed to view
+5. Show page template issue
+
+---
+
+## Files to Check
+
+- `resources/views/team/show.blade.php` (main detail page)
+- `resources/views/livewire/team/member-ai-config.blade.php`
+- `app/Livewire/Team/MemberAiConfig.php`
+- `app/Http/Controllers/TeamController.php` (show method)
+
+---
+
+## Debugging Steps
+
+1. Check browser console for JS errors
+2. Check Livewire network requests
+3. Verify `$member` is passed and not null
+4. Check Alpine.js initialization
+5. Inspect tab switching logic
+6. Check CSS (hidden content)
+
+---
+
+## Acceptance Criteria
+
+- [ ] Detail page loads with content
+- [ ] Overview tab shows member info
+- [ ] AI Config tab shows form
+- [ ] Tab switching works
+- [ ] No console/Livewire errors
+
+---
+
+**Repro:** Navigate to `/team/{any-uuid}` → Both tabs empty

--- a/resources/views/livewire/team/member-ai-config.blade.php
+++ b/resources/views/livewire/team/member-ai-config.blade.php
@@ -27,23 +27,27 @@
             </h2>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div>
-                    <label class="block text-sm font-medium text-slate-300 mb-2">AI Model</label>
-                    <input type="text" wire:model="ai_model" 
-                           class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-2 text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors">
-                    @error('ai_model')
+                    <label class="block text-sm font-medium text-slate-300 mb-2">Model</label>
+                    <select wire:model="model" 
+                            class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-2 text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors">
+                        @foreach($availableModels as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                    @error('model')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
                 
                 <div>
                     <label class="block text-sm font-medium text-slate-300 mb-2">Response Style</label>
-                    <select wire:model="response_style" 
+                    <select wire:model="responseStyle" 
                             class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-2 text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors">
                         @foreach($responseStyles as $value => $label)
                             <option value="{{ $value }}">{{ $label }}</option>
                         @endforeach
                     </select>
-                    @error('response_style')
+                    @error('responseStyle')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
@@ -76,9 +80,9 @@
                     <label class="block text-sm font-medium text-slate-300 mb-2">
                         Max Tokens
                     </label>
-                    <input type="number" wire:model="max_tokens" min="1" max="128000"
+                    <input type="number" wire:model="maxTokens" min="1" max="128000"
                            class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-2 text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors">
-                    @error('max_tokens')
+                    @error('maxTokens')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
@@ -86,11 +90,11 @@
                 <div>
                     <label class="block text-sm font-medium text-slate-300 mb-2">
                         Top P
-                        <span class="text-slate-500 text-xs ml-2">({{ $top_p }})</span>
+                        <span class="text-slate-500 text-xs ml-2">({{ $topP }})</span>
                     </label>
-                    <input type="range" wire:model.live="top_p" min="0" max="1" step="0.05"
+                    <input type="range" wire:model.live="topP" min="0" max="1" step="0.05"
                            class="w-full h-2 bg-white/10 rounded-lg appearance-none cursor-pointer accent-purple-500">
-                    @error('top_p')
+                    @error('topP')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
@@ -98,11 +102,11 @@
                 <div>
                     <label class="block text-sm font-medium text-slate-300 mb-2">
                         Frequency Penalty
-                        <span class="text-slate-500 text-xs ml-2">({{ $frequency_penalty }})</span>
+                        <span class="text-slate-500 text-xs ml-2">({{ $frequencyPenalty }})</span>
                     </label>
-                    <input type="range" wire:model.live="frequency_penalty" min="-2" max="2" step="0.1"
+                    <input type="range" wire:model.live="frequencyPenalty" min="-2" max="2" step="0.1"
                            class="w-full h-2 bg-white/10 rounded-lg appearance-none cursor-pointer accent-purple-500">
-                    @error('frequency_penalty')
+                    @error('frequencyPenalty')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
@@ -110,11 +114,11 @@
                 <div>
                     <label class="block text-sm font-medium text-slate-300 mb-2">
                         Presence Penalty
-                        <span class="text-slate-500 text-xs ml-2">({{ $presence_penalty }})</span>
+                        <span class="text-slate-500 text-xs ml-2">({{ $presencePenalty }})</span>
                     </label>
-                    <input type="range" wire:model.live="presence_penalty" min="-2" max="2" step="0.1"
+                    <input type="range" wire:model.live="presencePenalty" min="-2" max="2" step="0.1"
                            class="w-full h-2 bg-white/10 rounded-lg appearance-none cursor-pointer accent-purple-500">
-                    @error('presence_penalty')
+                    @error('presencePenalty')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
@@ -129,30 +133,30 @@
             <div class="space-y-6">
                 <div>
                     <label class="block text-sm font-medium text-slate-300 mb-2">System Prompt</label>
-                    <textarea wire:model="system_prompt" rows="4"
+                    <textarea wire:model="systemPrompt" rows="4"
                               class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors font-mono text-sm"
                               placeholder="Enter the base system prompt for this AI team member..."></textarea>
-                    @error('system_prompt')
+                    @error('systemPrompt')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
                 
                 <div>
                     <label class="block text-sm font-medium text-slate-300 mb-2">Persona Description</label>
-                    <textarea wire:model="persona_description" rows="3"
+                    <textarea wire:model="personaDescription" rows="3"
                               class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors text-sm"
                               placeholder="Describe the persona, character traits, and communication style..."></textarea>
-                    @error('persona_description')
+                    @error('personaDescription')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
                 
                 <div>
                     <label class="block text-sm font-medium text-slate-300 mb-2">Special Instructions</label>
-                    <textarea wire:model="special_instructions" rows="3"
+                    <textarea wire:model="specialInstructions" rows="3"
                               class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors text-sm"
                               placeholder="Any specific instructions or edge cases..."></textarea>
-                    @error('special_instructions')
+                    @error('specialInstructions')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
@@ -191,22 +195,22 @@
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div>
                     <label class="block text-sm font-medium text-slate-300 mb-2">Max Concurrent Tasks</label>
-                    <input type="number" wire:model="max_concurrent_tasks" min="1" max="10"
+                    <input type="number" wire:model="maxConcurrentTasks" min="1" max="10"
                            class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-2 text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors">
-                    @error('max_concurrent_tasks')
+                    @error('maxConcurrentTasks')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
                 
                 <div>
                     <label class="block text-sm font-medium text-slate-300 mb-2">Priority Level</label>
-                    <select wire:model="priority_level" 
+                    <select wire:model="priorityLevel" 
                             class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-2 text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors">
                         @foreach($priorityLevels as $value => $label)
                             <option value="{{ $value }}">{{ $label }}</option>
                         @endforeach
                     </select>
-                    @error('priority_level')
+                    @error('priorityLevel')
                         <p class="text-red-400 text-sm mt-1">{{ $message }}</p>
                     @enderror
                 </div>
@@ -214,18 +218,18 @@
                 <div>
                     <label class="block text-sm font-medium text-slate-300 mb-2">Auto-Assign</label>
                     <div class="flex items-center gap-3 mt-3">
-                        <button type="button" wire:click="$toggle('auto_assign_enabled')"
+                        <button type="button" wire:click="$toggle('autoAssign')"
                                 @class([
                                     'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                                    $auto_assign_enabled ? 'bg-purple-500' : 'bg-white/20'
+                                    $autoAssign ? 'bg-purple-500' : 'bg-white/20'
                                 ])>
                             <span @class([
                                 'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
-                                $auto_assign_enabled ? 'translate-x-6' : 'translate-x-1'
+                                $autoAssign ? 'translate-x-6' : 'translate-x-1'
                             ])></span>
                         </button>
                         <span class="text-slate-400 text-sm">
-                            {{ $auto_assign_enabled ? 'Enabled' : 'Disabled' }}
+                            {{ $autoAssign ? 'Enabled' : 'Disabled' }}
                         </span>
                     </div>
                 </div>

--- a/resources/views/livewire/team/member-ai-config.blade.php
+++ b/resources/views/livewire/team/member-ai-config.blade.php
@@ -1,4 +1,9 @@
 <div class="member-ai-config space-y-6">
+    @if(!$member)
+        <div class="bg-red-500/20 border border-red-500/30 rounded-lg p-4 text-red-400">
+            <p>⚠️ Unable to load member data. Please try refreshing the page.</p>
+        </div>
+    @else
     {{-- Back Link --}}
     <div class="mb-4">
         <a href="{{ route('team.show', $member->id) }}" class="inline-flex items-center gap-2 text-slate-400 hover:text-white transition-colors">
@@ -18,7 +23,6 @@
             ↻ Reset to Defaults
         </button>
     </div>
-
     <form wire:submit="save" class="space-y-8">
         {{-- Model Settings --}}
         <div class="bg-gradient-to-br from-slate-900/60 to-slate-950/60 backdrop-blur-xl rounded-2xl border border-white/10 p-6">
@@ -252,4 +256,5 @@
             </button>
         </div>
     </form>
+    @endif
 </div>

--- a/resources/views/team/show.blade.php
+++ b/resources/views/team/show.blade.php
@@ -95,7 +95,7 @@
     </div>
     
     {{-- Tab Content --}}
-    <div class="tab-content">
+    <div class="tabs-body">
         {{-- Overview Tab --}}
         <div x-show="activeTab === 'overview'" x-cloak>
             <div class="bg-gradient-to-br from-slate-900/60 to-slate-950/60 backdrop-blur-xl rounded-2xl border border-white/10">


### PR DESCRIPTION
## Summary

Fixes #31 - Team member detail pages showed empty content in both Overview and AI Config tabs.

## Root Cause

The `.tab-content` class was being hidden by DaisyUI's CSS (`display: none`). DaisyUI's tab system expects radio-button controlled visibility, but our Alpine.js tab switching conflicted with this.

## Fixes Applied

1. **Renamed `.tab-content` to `.tabs-body`** - Avoids DaisyUI CSS conflict
2. **Added missing `personaDescription` property** - Livewire blade template referenced this property
3. **Added missing `toggleCapability()` method** - Called by blade template capability toggles
4. **Added null check for ``** - Wrapped content in `@if(!)` to prevent errors
5. **Fixed null-safe operator** - Changed `->member->title` to `->member?->title`

## Testing

- ✅ Overview tab now displays member information, stats, and tasks
- ✅ AI Config tab now displays model settings, generation parameters, prompts, capabilities, and task settings
- ✅ Tab switching works smoothly via Alpine.js
- ✅ No console errors
- ✅ No Livewire errors

## Screenshots

**Before:** Empty tabs with no visible content

**After:** Both tabs display properly with all form fields and information visible